### PR TITLE
Cloning state data so it isn't mutate directly

### DIFF
--- a/FormMixin.js
+++ b/FormMixin.js
@@ -47,7 +47,8 @@ var FormMixin = {
 		var self = this;
 		var fields = this.Form_buildSchema();
 		var should_validate = this.state.submit_attempts > 0;
-		var data = this.state.data;
+		// Don't mutate the state data directly
+		var data = clone(this.state.data);
 
 		data[field_name] = new_value;
 


### PR DESCRIPTION
This was circumventing shouldComponentUpdate checks as nextState.data and this.state.data were immediately equal all the time.  This either broke forms so the wouldn't receive updated inputs or made it so the forms performed poorly because they would have to render every cycle even if no data was changed.
